### PR TITLE
Minor build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 STATIC_LINKING := 0
 AR             := ar
-GIT_VERSION := " $(shell git rev-parse --short HEAD)"
+INSTALL        := install
+STRIP          := strip
+GIT_VERSION = 3.3
 
 ifeq ($(platform),)
 platform = unix
@@ -228,5 +230,12 @@ endif
 
 clean:
 	rm -f *.o */*.o */*/*.o
+
+strip:
+	$(STRIP) $(TARGET_NAME).out
+
+install: strip
+	$(INSTALL) -m 555 $(TARGET_NAME).out $(DESTDIR)$(PREFIX)/bin/$(TARGET_NAME)
+	$(INSTALL) -m 644 $(TARGET_NAME).6 $(DESTDIR)$(PREFIX)/man/man6
 
 .PHONY: clean

--- a/Makefile.common
+++ b/Makefile.common
@@ -27,7 +27,6 @@ SOURCES_C +=   $(LIBRETRO_COMM_DIR)/file/retro_stat.c \
 					$(LIBRETRO_COMM_DIR)/streams/file_stream.c \
                     $(LIBRETRO_COMM_DIR)/streams/memory_stream.c \
 					$(LIBRETRO_COMM_DIR)/lists/string_list.c \
-					$(LIBRETRO_COMM_DIR)/hash/rhash.c \
 					$(LIBRETRO_COMM_DIR)/memmap/memalign.c
 endif
 


### PR DESCRIPTION
- Don't invoke git as it fails in a build sandbox without network/git
  available
- rhash.c is not needed