### PR TITLE
GIT_VERSION is not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ STATIC_LINKING := 0
 AR             := ar
 INSTALL        := install
 STRIP          := strip
-GIT_VERSION = 3.3
 
 ifeq ($(platform),)
 platform = unix


### PR DESCRIPTION
GIT_VERSION is not needed.

Test case:
```
# mrboom -v
Mr.Boom 3.3
```
