### PR TITLE
Make the desktop file actually work

### DIFF
--- a/Assets/mrboom.desktop
+++ b/Assets/mrboom.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
 Name=Mr.Boom
 Comment=8 player Bomberman clone
-Exec=/usr/games/mrboom
-TryExec=/usr/games/mrboom
+Exec=mrboom
 Icon=mrboom
 Terminal=false
 Categories=Game;ArcadeGame;ActionGame;


### PR DESCRIPTION
This makes `mrboom.desktop` actually work and any good package should have the name symlinked  or in the path so that it can be launched with the command `mrboom`. Without this it just doesn't wan't to show up in the menus...