### PR TITLE
Helper: Workaround gcc 7.5.0 division bug

### DIFF
--- a/ai/MrboomHelper.hpp
+++ b/ai/MrboomHelper.hpp
@@ -117,12 +117,14 @@ int victories(int player);
 
 int inline getAdderX(int player)
 {
-   return(GETXPIXELSTOCENTEROFCELL(player) * framesToCrossACell(player) / CELLPIXELSSIZE);
+   int sign = GETXPIXELSTOCENTEROFCELL(player) < 0 ? -1 : 1;
+   return((abs(GETXPIXELSTOCENTEROFCELL(player) * framesToCrossACell(player)) / CELLPIXELSSIZE) * sign);
 }
 
 int inline getAdderY(int player)
 {
-   return(GETYPIXELSTOCENTEROFCELL(player) * framesToCrossACell(player) / CELLPIXELSSIZE);
+   int sign = GETYPIXELSTOCENTEROFCELL(player) < 0 ? -1 : 1;
+   return((abs(GETYPIXELSTOCENTEROFCELL(player) * framesToCrossACell(player)) / CELLPIXELSSIZE) * sign);
 }
 
 bool isSuicideOK(int player);


### PR DESCRIPTION
Avoid incorrect negative division optimization. Fixes bot behavior on Gamecube