### PR TITLE
Fix SDL2 include path

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -111,8 +111,8 @@ const char *musics_filenames[NB_CHIPTUNES + PADDING_FALCON] = {
 };
 
 #ifdef __LIBSDL2__
-#include <SDL.h>
-#include <SDL_mixer.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
 #endif
 
 #ifdef __LIBSDL__


### PR DESCRIPTION
When compiling with LIBSDL2=1, this fixes the following issue with sdl2 provided by Homebrew:

common.cpp:115:10: fatal error: 'SDL_mixer.h' file not found
         ^~~~~~~~~~~~~
1 error generated.

I'm unsure why the path was wrong or if it changed at one point in SDL2, or if different package managers handle this differently?