### PR TITLE
use emar instead of em++ for archiving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_emscripten.bc
    fpic := -fPIC
    SHARED := -shared
+   AR=emar
    STATIC_LINKING := 1
    CFLAGS += -DNO_NETWORK
 
@@ -738,9 +739,7 @@ endif
 all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
-ifeq ($(platform), emscripten)
-	$(CXX) $(fpic) -r $(SHARED) $(INCLUDES) -o $@ $(OBJECTS) $(LDFLAGS)
-else ifeq ($(STATIC_LINKING), 1)
+ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else ifeq ($(platform),genode)
 	$(LD) -o $@ $(OBJECTS) $(LDFLAGS)


### PR DESCRIPTION
Per https://github.com/libretro/RetroArch/pull/15688

I'm sending this here instead of libretro/mrboom-libretro because it seems like this is the proper upstream, but please let me know if I should file this against the other repo.